### PR TITLE
set infotext after swapping node

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -362,17 +362,6 @@ chesttools.update_chest = function(pos, formname, fields, player)
 		player_inv:add_item(    'main', old_price_item..' '..tostring(old_price_amount));
 	end
 
-	-- set the owner field
-	meta:set_string( 'owner', pname );
-
-	if( fields.locked ) then
-		meta:set_string("infotext", "Locked Chest (owned by "..meta:get_string("owner")..")")
-	elseif( fields.shared ) then
-		meta:set_string("infotext", "Shared Chest (owned by "..meta:get_string("owner")..")")
-	else
-		meta:set_string("infotext", "Chest")
-	end
-
 	-- copy the old inventory
 	local inv = meta:get_inventory();
 	local main_inv = {};
@@ -386,6 +375,14 @@ chesttools.update_chest = function(pos, formname, fields, player)
 	minetest.set_node( pos, { name = new_node_name, param2 = node.param2 });
 	-- make sure the player owns the new chest
 	meta:set_string("owner", pname);
+
+	if( fields.locked ) then
+		meta:set_string("infotext", "Locked Chest (owned by "..pname..")")
+	elseif( fields.shared ) then
+		meta:set_string("infotext", "Shared Chest (owned by "..pname..")")
+	else
+		meta:set_string("infotext", "Chest")
+	end
 
 	-- put the inventory back
 	local new_inv      = meta:get_inventory();


### PR DESCRIPTION
currently, the infotext is set before `set_node` is called, which causes the metadata to be erased, and the infotext to be set in `on_construct`. this results in the infotext missing the owner's name. 

the solution is to set the infotext after `set_node`. 